### PR TITLE
 Include task delete at zones and nodes level

### DIFF
--- a/automationclient/tests/v1_1/fakes.py
+++ b/automationclient/tests/v1_1/fakes.py
@@ -538,6 +538,7 @@ def _stub_task(**kwargs):
         {
             "state": "PENDING",
             "id": "1234",
+            "uuid": "1234",
             "result": "NOT_READY"
         }
 
@@ -722,6 +723,12 @@ class FakeHTTPClient(base_client.HTTPClient):
             {'id': 5678, 'name': 'sample-tasks2'}
         ]})
 
+    def get_zones_1234_tasks_1234(self, **kw):
+        return (200, {}, {'task': _stub_task(id='1234')})
+
+    def delete_zones_1234_tasks_1234(self):
+        return (204, {}, {})
+
     def put_zones_1234(self, **kw):
         return (200, {}, {'zone': _stub_zone(id='1234')})
 
@@ -807,6 +814,9 @@ class FakeHTTPClient(base_client.HTTPClient):
 
     def get_zones_1234_nodes_1234_tasks_1234(self):
         return (200, {}, {'task': _stub_task(id='1234')})
+
+    def delete_zones_1234_nodes_1234_tasks_1234(self):
+        return (204, {}, {})
 
     def post_zones_1234_nodes_1234_tasks_1234_cancel(self):
         return (200, {}, {'task': _stub_task(id='1234')})

--- a/automationclient/tests/v1_1/test_nodes.py
+++ b/automationclient/tests/v1_1/test_nodes.py
@@ -63,6 +63,19 @@ class NodeTest(utils.TestCase):
         cs.assert_called('GET', '/zones/1234/nodes/1234/tasks/1234')
         self.assertIsInstance(task, Task)
 
+    def test_zone_task_delete(self):
+        zone = cs.zones.get(1234)
+        cs.assert_called('GET', '/zones/1234')
+        self.assertIsInstance(zone, Zone)
+        node = cs.nodes.get(zone, 1234)
+        cs.assert_called('GET', '/zones/1234/nodes/1234')
+        self.assertIsInstance(node, Node)
+        task = cs.tasks.get(zone, 1234)
+        cs.assert_called('GET', '/zones/1234/tasks/1234')
+        self.assertIsInstance(task, Task)
+        cs.tasks.delete(zone, task, node)
+        cs.assert_called('DELETE', '/zones/1234/nodes/1234/tasks/1234')
+
     def test_node_task_cancel(self):
         zone = cs.zones.get(1234)
         cs.assert_called('GET', '/zones/1234')

--- a/automationclient/tests/v1_1/test_shell.py
+++ b/automationclient/tests/v1_1/test_shell.py
@@ -600,6 +600,10 @@ class ShellTest(utils.TestCase):
         self.run_command('zone-tasks-list 1234')
         self.assert_called('GET', '/zones/1234/tasks')
 
+    def test_zone_task_delete(self):
+        self.run_command('zone-task-delete 1234 1234')
+        self.assert_called('DELETE', '/zones/1234/tasks/1234')
+
     def test_zone_property_create(self):
         self.run_command('zone-property-create '
                          '1234 new_fake_property_key new_fake_property_value')
@@ -727,6 +731,10 @@ class ShellTest(utils.TestCase):
     def test_node_tasks_list(self):
         self.run_command('node-tasks-list 1234 1234')
         self.assert_called('GET', '/zones/1234/nodes/1234/tasks')
+
+    def test_node_task_delete(self):
+        self.run_command('node-task-delete 1234 1234 1234')
+        self.assert_called('DELETE', '/zones/1234/nodes/1234/tasks/1234')
 
     def test_node_task_state(self):
         self.run_command('node-task-state 1234 1234 1234')

--- a/automationclient/tests/v1_1/test_zones.py
+++ b/automationclient/tests/v1_1/test_zones.py
@@ -175,6 +175,16 @@ class ZonesTest(utils.TestCase):
         self.assertEqual(len(tasks), 2)
         [self.assertTrue(isinstance(task, Task)) for task in tasks]
 
+    def test_zone_task_delete(self):
+        zone = cs.zones.get(1234)
+        cs.assert_called('GET', '/zones/1234')
+        self.assertIsInstance(zone, Zone)
+        task = cs.tasks.get(zone, 1234)
+        cs.assert_called('GET', '/zones/1234/tasks/1234')
+        self.assertIsInstance(task, Task)
+        cs.tasks.delete(zone, task)
+        cs.assert_called('DELETE', '/zones/1234/tasks/1234')
+
     def test_zone_propery_create(self):
         zone = cs.zones.get(1234)
         cs.assert_called('GET', '/zones/1234')

--- a/automationclient/v1_1/shell.py
+++ b/automationclient/v1_1/shell.py
@@ -93,8 +93,11 @@ def _find_service(cs, zone, role, component, service):
 
 def _find_task(cs, zone, node, task):
     obj_zone = _find_zone(cs, zone)
-    obj_node = _find_node(cs, zone, node)
-    return cs.tasks.get_node(obj_zone, obj_node, task)
+    if node is not None:
+        obj_node = _find_node(cs, zone, node)
+        return cs.tasks.get_node(obj_zone, obj_node, task)
+    else:
+        return cs.tasks.get(obj_zone, task)
 
 
 @utils.service_type('automation')
@@ -731,6 +734,20 @@ def do_zone_tasks_list(cs, args):
 
 @utils.arg('zone', metavar='<zone-id>',
            type=int,
+           help='ID of the zone.')
+@utils.arg('task', metavar='<task-id>',
+           type=str,
+           help='ID of the task.')
+@utils.service_type('automation')
+def do_zone_task_delete(cs, args):
+    """Remove a task by zone from automation DB."""
+    zone = _find_zone(cs, args.zone)
+    task = _find_task(cs, args.zone, None, args.task)
+    cs.tasks.delete(zone, task)
+
+
+@utils.arg('zone', metavar='<zone-id>',
+           type=int,
            help='ID of the zone to create a property.')
 @utils.arg('property_key', metavar='<property-key>',
            help='The key property.')
@@ -842,6 +859,24 @@ def do_node_task_state(cs, args):
     """Show details about a task from a node in a zone."""
     task = _find_task(cs, args.zone, args.node, args.task)
     utils.print_dict(task._info)
+
+
+@utils.arg('zone', metavar='<zone-id>',
+           type=int,
+           help='ID of the zone.')
+@utils.arg('node', metavar='<node-id>',
+           type=int,
+           help='ID of the node.')
+@utils.arg('task', metavar='<task-id>',
+           type=str,
+           help='ID of the task.')
+@utils.service_type('automation')
+def do_node_task_delete(cs, args):
+    """Remove a task from a node in a zone from automation DB."""
+    zone = _find_zone(cs, args.zone)
+    node = _find_node(cs, args.zone, args.node)
+    task = _find_task(cs, args.zone, None, args.task)
+    cs.tasks.delete(zone, task, node)
 
 
 @utils.arg('zone', metavar='<zone-id>',

--- a/automationclient/v1_1/tasks.py
+++ b/automationclient/v1_1/tasks.py
@@ -51,7 +51,7 @@ class TaskManager(base.ManagerWithFind):
         """
         return self._list("/zones/%s/tasks" % zone.id, "tasks")
 
-    def get(self, zone, node, task):
+    def get(self, zone, task):
         """Get a specific task by zone.
 
         :param zone: The ID of the :class: `Zone` to get.
@@ -60,9 +60,8 @@ class TaskManager(base.ManagerWithFind):
         :param task: The ID of the :class: `Task` to get.
         :rtype: :class:`Task`
         """
-        return self._get("/zones/%s/nodes/%s/tasks/%s" % (base.getid(zone),
-                                                          base.getid(node),
-                                                          base.getid(task)),
+        return self._get("/zones/%s/tasks/%s" % (base.getid(zone),
+                                                 task),
                          "task")
 
     def deploy(self, zone, role, node, bypass, hostname, dhcp_reload):
@@ -183,3 +182,25 @@ class TaskManager(base.ManagerWithFind):
         res.zone = zone
         res.node = node
         return res
+
+    def delete(self, zone, task, node=None):
+        """
+        Delete a specific task.
+
+        :param zone: The  ID of the :class: `Zone` to get.
+        :rtype: :class:`Zone`
+
+        :param task: The UUID of the :class: `Task` to delete.
+        :rtype: :class:`Task`
+
+        :param node: The ID of the :class: `Node` to get
+        :rtype: :class:`Node`
+        """
+
+        if node is None:
+            self._delete("/zones/%s/tasks/%s" % (base.getid(zone),
+                                                 task.uuid))
+        else:
+            self._delete("/zones/%s/nodes/%s/tasks/%s" % (base.getid(zone),
+                                                          base.getid(node),
+                                                          task.uuid))


### PR DESCRIPTION
Has been created two new features to allow
delete task in REVOKED, FAILURE and SUCCESS states at
zone and node levels through the CLI.

Bug: STACKOPHEAD-495
