### PR TITLE
Bug/stackopshead 498

### DIFF
--- a/automationclient/tests/v1_1/test_nodes.py
+++ b/automationclient/tests/v1_1/test_nodes.py
@@ -83,7 +83,9 @@ class NodeTest(utils.TestCase):
         node = cs.nodes.get(zone, 1234)
         cs.assert_called('GET', '/zones/1234/nodes/1234')
         self.assertIsInstance(node, Node)
-        task = cs.tasks.cancel(zone, node, 1234)
+        task = cs.tasks.get_node(zone, node, 1234)
+        self.assertIsInstance(task, Task)
+        task = cs.tasks.cancel(zone, node, task)
         cs.assert_called('POST', '/zones/1234/nodes/1234/tasks/1234/cancel')
         self.assertIsInstance(task, tuple)
 

--- a/automationclient/v1_1/shell.py
+++ b/automationclient/v1_1/shell.py
@@ -857,7 +857,9 @@ def do_node_tasks_list(cs, args):
 @utils.service_type('automation')
 def do_node_task_state(cs, args):
     """Show details about a task from a node in a zone."""
-    task = _find_task(cs, args.zone, args.node, args.task)
+    zone = _find_zone(cs, args.zone)
+    node = _find_node(cs, args.zone, args.node)
+    task = cs.tasks.state(zone, node, args.task)
     utils.print_dict(task._info)
 
 
@@ -875,7 +877,7 @@ def do_node_task_delete(cs, args):
     """Remove a task from a node in a zone from automation DB."""
     zone = _find_zone(cs, args.zone)
     node = _find_node(cs, args.zone, args.node)
-    task = _find_task(cs, args.zone, None, args.task)
+    task = _find_task(cs, args.zone, args.node, args.task)
     cs.tasks.delete(zone, task, node)
 
 

--- a/automationclient/v1_1/tasks.py
+++ b/automationclient/v1_1/tasks.py
@@ -150,6 +150,24 @@ class TaskManager(base.ManagerWithFind):
                                                           task),
                          "task")
 
+    def state(self, zone, node, task):
+        """Get a specific task by zone and node.
+
+        :param zone: The ID of the :class: `Zone` to get.
+        :rtype: :class:`Zone`
+
+        :param profile: The ID of the :class: `Node` to get.
+        :rtype: :class:`Node`
+
+        :param profile: The ID of the :class: `Task` to get.
+        :rtype: :class:`Task`
+        """
+        return self._get("/zones/%s/nodes/%s/tasks/%s/state"
+                         % (base.getid(zone),
+                            base.getid(node),
+                            task),
+                         "task")
+
     def execute_service(self, zone, role, component, service, node):
         """Execute a specific service by zone, role, component
 

--- a/automationclient/v1_1/tasks.py
+++ b/automationclient/v1_1/tasks.py
@@ -118,7 +118,7 @@ class TaskManager(base.ManagerWithFind):
         return self.api.client.post("/zones/%s/nodes/%s/tasks/%s/cancel"
                                     % (base.getid(zone),
                                        base.getid(node),
-                                       base.getid(task)))
+                                       task.uuid))
 
     def list_node(self, zone, node):
         """Get all tasks by zone and node.


### PR DESCRIPTION
Task's state and get task by node improved …

Has been improve the CLI to have into account
the node level at the moment to get a task and
perform a delete operation over it, also has been
updated the task's state to get due to the change
made in the API.

Bug: STACKOPHEAD-497

Task 'cancel' ans 'state' improved at node level …

Has been modified the RESTful requests for
'cancel' and 'state' in automation therefore must be
updated the client. Related with pull request
StackOps/stackops-head#23

Bug: STACKOPHEAD-498
